### PR TITLE
Add CI via github actions

### DIFF
--- a/.github/workflows/build-agda.yaml
+++ b/.github/workflows/build-agda.yaml
@@ -1,0 +1,20 @@
+name: Build Agda
+on:
+  pull_request:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout code
+
+      - uses: cachix/install-nix-action@v13
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Check agda code
+        run: |
+          nix-shell shell.nix --command 'agda -i "." Everything.agda'

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,7 @@
+{ pkgs ? import <nixpkgs> {} }:
+let
+  agdaWithStandardLibrary = pkgs.agda.withPackages (p: [ p.standard-library ]);
+in
+  pkgs.mkShell {
+    buildInputs = [ agdaWithStandardLibrary ];
+  }


### PR DESCRIPTION
Adds a CI step to build the 'Everything.agda' file with a version of agda+stdlib from dockerhub. (Fixes #8).

~Based on [this example](https://github.com/JonasHoefer/scoped-effects-agda/blob/a7b93ed465e554114e453b3278ac9d6c083c365c/.github/workflows/ci-pipeline.yml).~

Todo/To discuss:

- [x] ~It doesn't build at the moment? Is that because something is missing or because of the setup?~

It's because of the older Agda/stdlib I think.

<details>
Here's the build error:

```
[Build Agda/build] ⭐  Run Check Agda Code
| Checking Everything (/github/workspace/Everything.agda).
|  Checking Show (/github/workspace/Show.agda).
| /github/workspace/Show.agda:32,10-29
| Failed to find source of module Data.Fin.Show in any of the                                                              
| following locations:
|   /root/.agda/lib/standard-library/src/Data/Fin/Show.agda
|   /root/.agda/lib/standard-library/src/Data/Fin/Show.lagda
|   /github/workspace/Data/Fin/Show.agda
|   /github/workspace/Data/Fin/Show.lagda
|   /github/workspace/Data/Fin/Show.agda
|   /github/workspace/Data/Fin/Show.lagda
|   /root/.agda/src/.stack-work/install/x86_64-linux/1e00b9ab146f000e5939314a3f7d999792a6fde726b96f5a16d953eaba093987/8.8.3/share/x86_64-linux-ghc-8.8.3/Agda-2.6.1/lib/prim/Data/Fin/Show.agda
|   /root/.agda/src/.stack-work/install/x86_64-linux/1e00b9ab146f000e5939314a3f7d999792a6fde726b96f5a16d953eaba093987/8.8.3/share/x86_64-linux-ghc-8.8.3/Agda-2.6.1/lib/prim/Data/Fin/Show.lagda
| when scope checking the declaration
|   import Data.Fin.Show as FS
```

</details>

- [x] ~Does it need a newer Agda? Release a new image on dockerhub or do something else?~ (Yes).
- [x] ~Use the Makefile? (It doesn't work at the moment because the location of the stdlib needs to be passed in directly)~ (The `make Test` target didn't work for me on my own testing with the Nix shell like so:
```
MAlonzo/Code/Categorical/Equiv.hs:566:3: error:
    Not in scope:
      type constructor or class ‘MAlonzo.Code.Relation.Binary.Reasoning.Base.Single.T26’
    Module ‘MAlonzo.Code.Relation.Binary.Reasoning.Base.Single’ does not export ‘T26’.
    |
566 |   MAlonzo.Code.Relation.Binary.Reasoning.Base.Single.T26
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

but my local setup worked fine, and also worked fine when I did it via the nix shell myself. 🤷🏻 )


- [x] ~Does caching work? Are the builds fast or slow?~
- [x] ~Set up caching~ (Everything is cached with nix)
- [ ] We could deploy docs to github pages (see link below)

~Other examples to potentially follow instead:~
- ~https://doisinkidney.com/posts/2020-11-18-agda-github-action.html~

~(I opted for this approach as it was way simpler.)~

Trivia:

- ~I tested this locally with [act](https://github.com/nektos/act); it worked nicely!~ (Big regrets trying act; it doesn't play well with nix or many other important things.)